### PR TITLE
Parametrize viewpoint in 3D plots and bugfix in azimuth / altitude order in LightSource

### DIFF
--- a/clearplot/plot_functions.py
+++ b/clearplot/plot_functions.py
@@ -1069,7 +1069,8 @@ def show_im(filename, im_seq, **kwargs):
 def plot_surface(filename, x, y, z, x_label='x', y_label='y', z_label='z', \
     x_lim = [None,None], y_lim = [None,None], z_lim = [None,None],\
     x_tick = None, y_tick = None, z_tick = None, \
-    light_alt_angle = 0.0, light_azm_angle = 90.0, title = 'None', \
+    light_alt_angle = 0.0, light_azm_angle = 90.0, \
+    view_alt_angle = 20.0, view_azm_angle = 30.0, title = 'None', \
     c_map = _cp.colors.c_maps['plain_red']):
     """
     Plots a 3D surface.  In development...
@@ -1137,13 +1138,13 @@ def plot_surface(filename, x, y, z, x_label='x', y_label='y', z_label='z', \
     
     #Specify the viewing angle 
     #(elev = angle above z plane, azim = angle about the z-axis)
-    axes3d.view_init(elev=20, azim=-30)
+    axes3d.view_init(elev=view_alt_angle, azim=view_azm_angle)
     # create light source object.
     #(I could not find any documentation on  on using a lightsource with a surface,
     #but the following forum post described what to do:
     #http://matplotlib.1069221.n5.nabble.com/Is-it-possible-to-have-different-color-for-inner-and-outer-face-of-a-3D-plot-td38979.html)
     #(altdeg = angle above z plane, azdeg = angle about the z-axis)
-    ls = mplc.LightSource(light_alt_angle, light_azm_angle)
+    ls = mplc.LightSource(azdeg=light_azm_angle, altdeg=light_alt_angle)
     illuminated_surf = ls.shade(xyz[2], cmap = c_map)
     surf = axes3d.plot_surface(xyz[0], xyz[1], xyz[2], \
         rstride=1, cstride=1, linewidth=0, antialiased=False, \
@@ -1161,7 +1162,8 @@ def plot_surface(filename, x, y, z, x_label='x', y_label='y', z_label='z', \
 def plot_3d_scatter(filename, x, y, z, x_label='x', y_label='y', z_label='z', \
     x_lim = [None,None], y_lim = [None,None], z_lim = [None,None],\
     x_tick = None, y_tick = None, z_tick = None, \
-    light_alt_angle = 0.0, light_azm_angle = 90.0, title = 'None'):
+    light_alt_angle = 0.0, light_azm_angle = 90.0, \
+    view_alt_angle = 20.0, view_azm_angle = -25.0, title = 'None'):
     """
     Plots a 3D scatter plot.  In development...
     """    
@@ -1229,7 +1231,7 @@ def plot_3d_scatter(filename, x, y, z, x_label='x', y_label='y', z_label='z', \
     
     #Specify the viewing angle 
     #(elev = angle above z plane, azim = angle about the z-axis)
-    axes3d.view_init(elev=20, azim=-25)
+    axes3d.view_init(elev=view_alt_angle, azim=view_azm_angle)
     scatter = axes3d.scatter(xyz[0], xyz[1], xyz[2])
         
     #Add Title


### PR DESCRIPTION
### 1. The azimuth and altitude in the `axes3d.view_init()` function was hardcoded.
 I modified the call to: `axes3d.view_init(elev=view_alt_angle, azim=view_azm_angle)` with the 2 new arguments `view_alt_angle` and `view_azm_angle` added to the function signatures of `plot_surface()` and `plot_3d_scatter()`.

### 2. The azimuth and altitude order in `mplc.LightSource()` was swapped

The [documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.LightSource.html#) gives positional arguments `azdeg` first and `altdeg` second. The function was called as: `mplc.LightSource(light_alt_angle, light_azm_angle)`, i.e., with altitude first and azimuth second. I swapped the order and used keyword arguments instead to correct and disambiguate the call to `mplc.LightSource()`
